### PR TITLE
added support for textmate tokens in monaco-editor

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -44,9 +44,10 @@ export default function emmetHTML(monaco = window.monaco) {
   return onCompletion(
     monaco,
     "html",
-    (tokens, index) =>
-      tokens[index].type === "" &&
-      (index === 0 || tokens[index - 1].type === "delimiter.html"),
+    (tokens, index) => {
+      return (tokens[index].type === "" && (index === 0 || (tokens[index - 1].type === "delimiter.html")) ||
+        (tokens[0].type === "text.html.basic"))
+    },
     str => {
       // empty or ends with white space, illegal
       if (str === "" || str.match(/\s$/)) return;


### PR DESCRIPTION
If monaco-editor is used with [monaco-textmate](https://github.com/NeekSandhu/monaco-textmate) package, all the grammar tokens for the editor are changed.

 Since this emmet extension depends on grammar token-type to provide html code completions, it stops working with the new tokens provided by the by the monaco-textmate. 

This commit simply adds both way compatibility for this extansion to work, both with normal monaco-editor package, and monaco editor used with monaco-textmate. 

Also, you may need to build the dist folder again for the changes to take effect.