### PR TITLE
Add MDX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `emmet` functionality was bound to language features not to a specific edito
 
 - `emmetHTML` works for `HTML` compatible languages, like `PHP`, for `html` only by default
 - `emmetCSS` works for `CSS` compatible languages, like `LESS` / `SCSS`, for `css` only by default
-- `emmetJSX` works for `JSX` compatible languages, like `JavaScript` / `TypeScript`, for `javascript` only by default
+- `emmetJSX` works for `JSX` compatible languages, like `JavaScript` / `TypeScript` / `MDX`, for `javascript` only by default
 
 _Follow [this](https://github.com/microsoft/monaco-editor/issues/264#issuecomment-654578687) guide to make Monaco Editor support `TSX`_
 

--- a/example/mdx.html
+++ b/example/mdx.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="color-scheme" content="light dark" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Monaco Emmet Example</title>
+    <style>
+      body > div {
+        float: left;
+        width: 100%;
+      }
+
+      .container {
+        height: 600px;
+        border: 1px solid black;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="mdx">
+      <h2>MDX</h2>
+      <div class="container"></div>
+    </div>
+    <script src="../node_modules/monaco-editor/min/vs/loader.js"></script>
+    <script src="../dist/emmet-monaco.js"></script>
+    <script>
+      require.config({ paths: { vs: '../node_modules/monaco-editor/min/vs' } })
+      require(['vs/editor/editor.main'], function () {
+        var containers = document.getElementsByClassName('container')
+
+        emmetMonaco.emmetJSX(monaco, ['mdx'])
+        monaco.editor.create(containers[0], {
+          value: `# Hello
+
+export function foo() {
+  return <div className="foo" id="bar"></div>
+}
+`,
+          language: 'mdx',
+          theme: matchMedia('(prefers-color-scheme: dark)').matches ? 'vs-dark' : 'vs-light',
+        })
+      })
+    </script>
+  </body>
+</html>

--- a/src/abbreviationActions.ts
+++ b/src/abbreviationActions.ts
@@ -7,7 +7,8 @@ interface Token {
 }
 
 function isValidEmmetToken(tokens: Token[], index: number, syntax: string, language: string): boolean {
-  const currentTokenType = tokens[index].type
+  const currentToken = tokens[index]
+  const currentTokenType = currentToken.type
 
   if (syntax === 'html') {
     // prevent emmet triggered within attributes
@@ -25,6 +26,10 @@ function isValidEmmetToken(tokens: Token[], index: number, syntax: string, langu
   }
 
   if (syntax === 'jsx') {
+    if (currentToken.language === 'mdx' && currentTokenType === '') {
+      return true
+    }
+
     // type must be `identifier` and not at start
     return (
       !!index &&


### PR DESCRIPTION
The MDX support is based on microsoft/monaco-editor#3096, which hasn’t been merged yet. I suggest to wait for that before merging, as the language tokenizer may change in code review.